### PR TITLE
(post) createChannel 응답값 수정, (post) createChannelUser 핸들러 추가

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -4,6 +4,7 @@ import ChannelAPI from './channelAPi';
 import storageProfileAPI from './storageProfileAPI';
 import TodoAPI from './todoAPi';
 import workspaceUserAPI from './workspaceUserAPI';
+import channelUserAPI from './channelUser';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -13,6 +14,7 @@ class API {
   channel;
   workspaceUser;
   storageProfile;
+  channelUser;
 
   constructor() {
     this.axios = axios.create({ baseURL: BASE_URL });
@@ -21,7 +23,7 @@ class API {
     this.channel = new ChannelAPI(this.axios);
     this.workspaceUser = new workspaceUserAPI(this.axios);
     this.storageProfile = new storageProfileAPI(this.axios);
-
+    this.channelUser = new channelUserAPI(this.axios);
   }
 }
 

--- a/src/api/channelAPi.ts
+++ b/src/api/channelAPi.ts
@@ -1,8 +1,5 @@
-import { ChannelInsertType } from '@/types/channel';
-import { Tables } from '@/types/supabase';
+import { ChannelInsertType, ChannelType } from '@/types/channel';
 import { AxiosInstance } from 'axios';
-
-type Channel = Tables<'channel'>;
 
 class ChannelAPI {
   private axios: AxiosInstance;
@@ -13,7 +10,7 @@ class ChannelAPI {
     this.path = '/api/channel';
   }
 
-  async getChannelList(type: string, workspace_id: number): Promise<Channel[]> {
+  async getChannelList({type, workspace_id}: Pick<ChannelType, 'type' | 'workspace_id'>): Promise<ChannelType[]> {
     const response = await this.axios.get(this.path, {
       params: {
         type,

--- a/src/api/channelUser.ts
+++ b/src/api/channelUser.ts
@@ -1,0 +1,23 @@
+import { ChannelUserType } from '@/types/channelUser';
+import { AxiosInstance } from 'axios';
+
+type CreateChannelUserParams = Pick<ChannelUserType, 'channel_id'> & { workspaceUserIds: ChannelUserType['workspace_user_id'][] };
+
+class channelUserAPI {
+  private axios: AxiosInstance;
+
+  constructor(axios: AxiosInstance) {
+    this.axios = axios;
+  }
+
+  async createChannelUsers({ workspaceUserIds, channel_id }: CreateChannelUserParams) {
+    const path = '/api/channel-user';
+    const response = await this.axios.post(path, {
+      workspaceUserIds,
+      channel_id
+    });
+    return response.data;
+  }
+}
+
+export default channelUserAPI;

--- a/src/app/(providers)/(root)/video-channel/_components/VideoList/VideoList.tsx
+++ b/src/app/(providers)/(root)/video-channel/_components/VideoList/VideoList.tsx
@@ -9,7 +9,7 @@ const VideoList = () => {
   const userName = 'minkon';
 
   const router = useRouter();
-  const { channelList } = useChannel('video', workspace_id);
+  const { channelList } = useChannel({ type: 'video', workspace_id });
 
   if (!channelList) {
     return <div>목록이 없습니다..</div>;

--- a/src/app/(providers)/(root)/video-channel/page.tsx
+++ b/src/app/(providers)/(root)/video-channel/page.tsx
@@ -8,7 +8,7 @@ import VideoList from './_components/VideoList';
 
 const MakeVideoCallRoom = () => {
   const router = useRouter();
-  const { addChannel } = useChannel('video', 2);
+  const { addChannel } = useChannel({ type: 'video', workspace_id: 2 });
   const [roomName, setRoomName] = useState<string>('');
   // TODO: 추후 유저정보 받아올 수 있으면 수정
   const [userName, setUserName] = useState<string>('');

--- a/src/app/api/channel-user/constants.ts
+++ b/src/app/api/channel-user/constants.ts
@@ -1,0 +1,5 @@
+export const CHANNEL_USER_RESPONSE = {
+  INVALID_REQUEST: '요청 형식이 올바르지 않습니다. (Hint: workspaceUserIds는 배열이여야 합니다, 또한 channel_id는 필수로 전달해야 합니다.)',
+  FAILED_TO_CREATE: '채널 유저 데이터 생성에 실패했습니다.',
+  SUCCESS_TO_CREATE: '채널 유저 데이터 생성에 성공했습니다.',
+};

--- a/src/app/api/channel-user/route.ts
+++ b/src/app/api/channel-user/route.ts
@@ -1,0 +1,35 @@
+import { createChannelUsers } from "@/services/channelUser";
+import { NextRequest, NextResponse } from "next/server";
+import { CHANNEL_USER_RESPONSE } from "./constants";
+
+/**
+ * Channel User POST 요청 핸들러
+ * @throws {Error} - userIds가 배열이 아니거나 channel_id가 없는 경우
+ */
+export const POST = async (request: NextRequest) => {
+  const { workspaceUserIds, channel_id } = await request.json();
+
+  if (!Array.isArray(workspaceUserIds) || !channel_id) {
+    return NextResponse.json({ message: CHANNEL_USER_RESPONSE.INVALID_REQUEST });
+  }
+
+  try {
+    const { error } = await createChannelUsers({ workspaceUserIds, channel_id });
+
+    if (error)
+      return NextResponse.json({
+        message: CHANNEL_USER_RESPONSE.FAILED_TO_CREATE,
+        error,
+        status: false,
+        statusCode: 500
+      });
+    return NextResponse.json({ message: CHANNEL_USER_RESPONSE.SUCCESS_TO_CREATE });
+  } catch (error) {
+    return NextResponse.json({
+      message: CHANNEL_USER_RESPONSE.FAILED_TO_CREATE,
+      error,
+      status: false,
+      statusCode: 500
+    });
+  }
+};

--- a/src/app/api/channel/route.ts
+++ b/src/app/api/channel/route.ts
@@ -1,5 +1,6 @@
 // pages/api/channel.js
 
+import { createChannel } from '@/services/channel';
 import { createClient } from '@/utils/supabase/supabaseServer';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -35,11 +36,9 @@ export const GET = async (request: NextRequest) => {
 };
 
 export const POST = async (request: NextRequest) => {
-  const supabase = createClient();
-
   const { name, type, workspace_id } = await request.json();
   try {
-    const { error } = await supabase.from('channel').insert({ name, type, workspace_id });
+    const { data, error } = await createChannel({ name, type, workspace_id });
 
     if (error)
       return NextResponse.json({
@@ -48,7 +47,7 @@ export const POST = async (request: NextRequest) => {
         status: false,
         statusCode: 500
       });
-    return NextResponse.json({ message: 'Create Channel' });
+    return NextResponse.json(data);
   } catch (error) {
     return NextResponse.json({
       message: 'Failed to insert data',

--- a/src/constants/channel.ts
+++ b/src/constants/channel.ts
@@ -1,0 +1,4 @@
+export const CHANNEL_TYPE = {
+  chat: 'chat',
+  video: 'video'
+} as const;

--- a/src/hooks/useChannel.ts
+++ b/src/hooks/useChannel.ts
@@ -1,8 +1,8 @@
 import api from '@/api/api';
-import { ChannelInsertType } from '@/types/channel';
+import { ChannelInsertType, ChannelType } from '@/types/channel';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-const useChannel = (type: 'chat' | 'video', workspace_id: number) => {
+const useChannel = ({ type, workspace_id }: Pick<ChannelType, 'type' | 'workspace_id'>) => {
   const queryClient = useQueryClient();
   const {
     data: channelList,
@@ -10,7 +10,7 @@ const useChannel = (type: 'chat' | 'video', workspace_id: number) => {
     isError
   } = useQuery({
     queryKey: ['channel'],
-    queryFn: () => api.channel.getChannelList(type, workspace_id)
+    queryFn: () => api.channel.getChannelList({type, workspace_id})
   });
 
   const { mutateAsync: addChannel } = useMutation({

--- a/src/services/channel.ts
+++ b/src/services/channel.ts
@@ -1,0 +1,14 @@
+import type { ChannelInsertType } from "@/types/channel";
+import { createClient } from "@/utils/supabase/supabaseServer";
+
+export const createChannel = async ({ name, type, workspace_id }: ChannelInsertType) => {
+  const supabase = createClient();
+
+  const response = await supabase.from('channel').insert({
+    name,
+    type,
+    workspace_id
+  }).select('id').single();
+
+  return response;
+};

--- a/src/services/channelUser.ts
+++ b/src/services/channelUser.ts
@@ -1,0 +1,19 @@
+import type { ChannelUserType } from "@/types/channelUser";
+import { createClient } from "@/utils/supabase/supabaseServer";
+
+type CreateChannelUsersProps = {
+  workspaceUserIds: ChannelUserType['workspace_user_id'][]
+} & Pick<ChannelUserType, 'channel_id'>;
+
+export const createChannelUsers = async ({ workspaceUserIds, channel_id }: CreateChannelUsersProps) => {
+  const supabase = createClient();
+
+  const bulkData = workspaceUserIds.map((userId) => ({
+    workspace_user_id: userId,
+    channel_id
+  }));
+
+  const response = await supabase.from('channel_user').insert(bulkData);
+
+  return response;
+};

--- a/src/types/channel.ts
+++ b/src/types/channel.ts
@@ -1,16 +1,13 @@
+import { CHANNEL_TYPE } from '@/constants/channel';
 import { Tables } from './supabase';
 
 // `channel` 테이블의 Row 타입
-export type ChannelType = Tables<'channel'>;
+export type ChannelType = {
+  type: keyof typeof CHANNEL_TYPE
+} & Omit<Tables<'channel'>, 'type'>;
 
 // `channel` 테이블의 Insert 타입
-export type ChannelInsertType = {
-  created_at?: string;
-  id?: number;
-  name?: string | null;
-  type?: string | null;
-  workspace_id?: number | null;
-};
+export type ChannelInsertType = Pick<ChannelType, 'name' | 'type' | 'workspace_id'>;
 
 // `channel` 테이블의 Update 타입
 export type ChannelUpdateType = {

--- a/src/types/channelUser.ts
+++ b/src/types/channelUser.ts
@@ -1,0 +1,3 @@
+import { Tables } from './supabase';
+
+export type ChannelUserType = Tables<'channel_user'>;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -47,35 +47,38 @@ export type Database = {
           created_at: string
           id: number
           last_read_chat_id: number | null
-          user_id: string
+          user_id: string | null
+          workspace_user_id: string | null
         }
         Insert: {
           channel_id: number
           created_at?: string
           id?: number
           last_read_chat_id?: number | null
-          user_id: string
+          user_id?: string | null
+          workspace_user_id?: string | null
         }
         Update: {
           channel_id?: number
           created_at?: string
           id?: number
           last_read_chat_id?: number | null
-          user_id?: string
+          user_id?: string | null
+          workspace_user_id?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "channel_user_workspace_user_id_fkey"
+            columns: ["workspace_user_id"]
+            isOneToOne: false
+            referencedRelation: "workspace_user"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "room_user_room_id_fkey"
             columns: ["channel_id"]
             isOneToOne: false
             referencedRelation: "channel"
-            referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "room_user_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "user"
             referencedColumns: ["id"]
           },
         ]
@@ -88,7 +91,7 @@ export type Database = {
           id: number
           is_notice: boolean
           type: string
-          user_id: string
+          workspace_user_id: string | null
         }
         Insert: {
           channel_id: number
@@ -97,7 +100,7 @@ export type Database = {
           id?: number
           is_notice: boolean
           type: string
-          user_id: string
+          workspace_user_id?: string | null
         }
         Update: {
           channel_id?: number
@@ -106,7 +109,7 @@ export type Database = {
           id?: number
           is_notice?: boolean
           type?: string
-          user_id?: string
+          workspace_user_id?: string | null
         }
         Relationships: [
           {
@@ -117,10 +120,10 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "chat_user_id_fkey"
-            columns: ["user_id"]
+            foreignKeyName: "chat_workspace_user_id_fkey"
+            columns: ["workspace_user_id"]
             isOneToOne: false
-            referencedRelation: "user"
+            referencedRelation: "workspace_user"
             referencedColumns: ["id"]
           },
         ]
@@ -160,37 +163,40 @@ export type Database = {
       todo: {
         Row: {
           end_date: string
-          id: number
-          is_done: boolean
+          id: string
           place: string | null
+          priority: string
           start_date: string
+          status: string
           title: string
           user_id: string
         }
         Insert: {
           end_date: string
-          id?: number
-          is_done: boolean
+          id?: string
           place?: string | null
+          priority: string
           start_date: string
+          status: string
           title: string
-          user_id?: string
+          user_id: string
         }
         Update: {
           end_date?: string
-          id?: number
-          is_done?: boolean
+          id?: string
           place?: string | null
+          priority?: string
           start_date?: string
+          status?: string
           title?: string
           user_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: "to_do_list_user_id_fkey"
+            foreignKeyName: "todo2_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
-            referencedRelation: "user"
+            referencedRelation: "workspace_user"
             referencedColumns: ["id"]
           },
         ]
@@ -201,21 +207,18 @@ export type Database = {
           email: string | null
           id: string
           sns_type: string | null
-          state: string | null
         }
         Insert: {
           created_at?: string
           email?: string | null
           id: string
           sns_type?: string | null
-          state?: string | null
         }
         Update: {
           created_at?: string
           email?: string | null
           id?: string
           sns_type?: string | null
-          state?: string | null
         }
         Relationships: [
           {
@@ -258,6 +261,7 @@ export type Database = {
           name: string | null
           phone: string | null
           profile_image: string | null
+          state: string | null
           user_id: string
           workspace_id: number | null
         }
@@ -267,6 +271,7 @@ export type Database = {
           name?: string | null
           phone?: string | null
           profile_image?: string | null
+          state?: string | null
           user_id: string
           workspace_id?: number | null
         }
@@ -276,6 +281,7 @@ export type Database = {
           name?: string | null
           phone?: string | null
           profile_image?: string | null
+          state?: string | null
           user_id?: string
           workspace_id?: number | null
         }
@@ -301,7 +307,39 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_channel_messages: {
+        Args: {
+          wid: number
+          wuid: string
+        }
+        Returns: {
+          channel_id: number
+          channel_name: string
+          message_created_at: string
+          message: string
+          is_dm: boolean
+          user_name: string
+          user_state: string
+          user_thumbnail: string
+          workspace_user_id: string
+          user_count: number
+        }[]
+      }
+      get_chat_messages: {
+        Args: {
+          cid: number
+        }
+        Returns: {
+          id: number
+          created_at: string
+          content: string
+          type: string
+          is_notice: boolean
+          workspace_user_id: string
+          name: string
+          profile_image: string
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -48,7 +48,7 @@ export type Database = {
           id: number
           last_read_chat_id: number | null
           user_id: string | null
-          workspace_user_id: string | null
+          workspace_user_id: string
         }
         Insert: {
           channel_id: number
@@ -56,7 +56,7 @@ export type Database = {
           id?: number
           last_read_chat_id?: number | null
           user_id?: string | null
-          workspace_user_id?: string | null
+          workspace_user_id: string
         }
         Update: {
           channel_id?: number
@@ -64,7 +64,7 @@ export type Database = {
           id?: number
           last_read_chat_id?: number | null
           user_id?: string | null
-          workspace_user_id?: string | null
+          workspace_user_id?: string
         }
         Relationships: [
           {
@@ -91,7 +91,7 @@ export type Database = {
           id: number
           is_notice: boolean
           type: string
-          workspace_user_id: string | null
+          workspace_user_id: string
         }
         Insert: {
           channel_id: number
@@ -100,7 +100,7 @@ export type Database = {
           id?: number
           is_notice: boolean
           type: string
-          workspace_user_id?: string | null
+          workspace_user_id: string
         }
         Update: {
           channel_id?: number
@@ -109,7 +109,7 @@ export type Database = {
           id?: number
           is_notice?: boolean
           type?: string
-          workspace_user_id?: string | null
+          workspace_user_id?: string
         }
         Relationships: [
           {
@@ -307,7 +307,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      get_channel_messages: {
+      get_chat_channels: {
         Args: {
           wid: number
           wuid: string


### PR DESCRIPTION
close #26 

- create channel (post) 응답 수정 bf3ba25
- create channel user (post) 핸들러 추가 f467d8f

channel에 대한 타입을 엄격하게 수정하였습니다.
커밋별로 보시면 수월합니다.

## 🔥 🔥 TODO: 
- 확인해보니 `useChannel` 이라는 Custom hook이 있지만, `mutate`만 return 해주고 있어서 사용하기 어려운 상황입니다.
- `data`도 같이 return 되어야 해당 hook을 사용할 수 있을 것 같아서 지금은 hook을 사용하지 않겠습니다.

## 🔥 🔥 CHECK:
![image](https://github.com/user-attachments/assets/c855dd5d-e849-4532-b613-fc55432c0646)
- 해당 파일 오타가 의도된 것인지, vscode의 대소문자 변경이 안되시는건지 궁금합니다! 문제가 생길 수 있어 당장은 제가 바꾸지는 않겠습니다.
- 전자라면 수정이 필요할 것이고, 후자라면 [해당 작업](https://velog.io/@sangbooom/vscode-%ED%8F%B4%EB%8D%94-%EB%8C%80%EC%86%8C%EB%AC%B8%EC%9E%90-%EB%B3%80%EA%B2%BD)을 해주시면 좋습니다.