### PR TITLE
/undefined 현상 해결

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,7 +19,7 @@ export const middleware = (request: NextRequest) => {
   const cookies = request.headers.get('cookie');
   const userToken = cookies
     ?.split('; ')
-    .find((row) => row.startsWith('userToken='))
+    .find((row) => row.startsWith('workspaceId='))
     ?.split('=')[1];
 
   if (pathname.startsWith(`/${workspaceId}`)) {


### PR DESCRIPTION
로그인 중 다른 브라우저에서 띄울 시 http://localhost:3100/undefined 해당 undefined주소가 나와 접속이 안되는 현상 해결